### PR TITLE
Fix storybook build error

### DIFF
--- a/stories/Verbum.stories.tsx
+++ b/stories/Verbum.stories.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
-import { Meta } from '@storybook/react';
 import { EditorComposer, Editor } from '../src';
-import PlaygroundApp from '../src/App';
 import ToolbarPlugin from '../src/plugins/ToolbarPlugin/ToolbarPlugin';
 import AlignDropdown from '../src/plugins/ToolbarPlugin/components/AlignDropdown';
-import { LexicalEditor } from 'lexical';
 import InsertDropdown from '../src/plugins/ToolbarPlugin/components/InsertDropdown';
 
-const meta: Meta = {
-  title: 'Welcome',
-  component: PlaygroundApp,
+export default {
+  title: 'Verbum',
 };
-
-export default meta;
 
 export const FullEditor = () => (
   <EditorComposer>


### PR DESCRIPTION
Currently we can't run `npm run storybook` because the build fails.

Error Log:
```
ERROR in ./stories/Verbum.stories.tsx
Module not found: Error: Can't resolve '../src/App' in '~/verbum/stories'
 @ ./stories/Verbum.stories.tsx 48:0-39 56:13-26
```