### PR TITLE
Added type button on buttons to avoid submit form

### DIFF
--- a/src/plugins/ActionsPlugin.tsx
+++ b/src/plugins/ActionsPlugin.tsx
@@ -122,6 +122,7 @@ export default function ActionsPlugin({
           }
           title="Speech To Text"
           aria-label={`${isSpeechToText ? 'Enable' : 'Disable'} speech to text`}
+          type="button"
         >
           <i className="mic" />
         </button>
@@ -131,6 +132,7 @@ export default function ActionsPlugin({
         onClick={() => importFile(editor)}
         title="Import"
         aria-label="Import editor state from JSON"
+        type="button"
       >
         <i className="import" />
       </button>
@@ -144,6 +146,7 @@ export default function ActionsPlugin({
         }
         title="Export"
         aria-label="Export editor state to JSON"
+        type="button"
       >
         <i className="export" />
       </button>
@@ -157,6 +160,7 @@ export default function ActionsPlugin({
         }}
         title="Clear"
         aria-label="Clear editor contents"
+        type="button"
       >
         <i className="clear" />
       </button>
@@ -167,6 +171,7 @@ export default function ActionsPlugin({
         }}
         title="Read-Only Mode"
         aria-label={`${isReadOnly ? 'Unlock' : 'Lock'} read-only mode`}
+        type="button"
       >
         <i className={isReadOnly ? 'unlock' : 'lock'} />
       </button>
@@ -175,6 +180,7 @@ export default function ActionsPlugin({
         onClick={handleMarkdownToggle}
         title="Convert From Markdown"
         aria-label="Convert from markdown"
+        type="button"
       >
         <i className="markdown" />
       </button>
@@ -190,6 +196,7 @@ export default function ActionsPlugin({
           aria-label={`${
             connected ? 'Disconnect from' : 'Connect to'
           } a collaborative editing server`}
+          type="button"
         >
           <i className={connected ? 'disconnect' : 'connect'} />
         </button>

--- a/src/plugins/CharacterStylesPopupPlugin.tsx
+++ b/src/plugins/CharacterStylesPopupPlugin.tsx
@@ -169,6 +169,7 @@ function FloatingCharacterStylesEditor({
         }}
         className={'popup-item spaced ' + (isBold ? 'active' : '')}
         aria-label="Format text as bold"
+        type="button"
       >
         <i className="format bold" />
       </button>
@@ -178,6 +179,7 @@ function FloatingCharacterStylesEditor({
         }}
         className={'popup-item spaced ' + (isItalic ? 'active' : '')}
         aria-label="Format text as italics"
+        type="button"
       >
         <i className="format italic" />
       </button>
@@ -187,6 +189,7 @@ function FloatingCharacterStylesEditor({
         }}
         className={'popup-item spaced ' + (isUnderline ? 'active' : '')}
         aria-label="Format text to underlined"
+        type="button"
       >
         <i className="format underline" />
       </button>
@@ -196,6 +199,7 @@ function FloatingCharacterStylesEditor({
         }}
         className={'popup-item spaced ' + (isStrikethrough ? 'active' : '')}
         aria-label="Format text with a strikethrough"
+        type="button"
       >
         <i className="format strikethrough" />
       </button>
@@ -206,6 +210,7 @@ function FloatingCharacterStylesEditor({
         className={'popup-item spaced ' + (isSubscript ? 'active' : '')}
         title="Subscript"
         aria-label="Format Subscript"
+        type="button"
       >
         <i className="format subscript" />
       </button>
@@ -216,6 +221,7 @@ function FloatingCharacterStylesEditor({
         className={'popup-item spaced ' + (isSuperscript ? 'active' : '')}
         title="Superscript"
         aria-label="Format Superscript"
+        type="button"
       >
         <i className="format superscript" />
       </button>
@@ -225,6 +231,7 @@ function FloatingCharacterStylesEditor({
         }}
         className={'popup-item spaced ' + (isCode ? 'active' : '')}
         aria-label="Insert code block"
+        type="button"
       >
         <i className="format code" />
       </button>
@@ -232,6 +239,7 @@ function FloatingCharacterStylesEditor({
         onClick={insertLink}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
         aria-label="Insert link"
+        type="button"
       >
         <i className="format link" />
       </button>
@@ -239,6 +247,7 @@ function FloatingCharacterStylesEditor({
         onClick={insertComment}
         className={'popup-item spaced ' + (isLink ? 'active' : '')}
         aria-label="Insert link"
+        type="button"
       >
         <i className="format add-comment" />
       </button>

--- a/src/plugins/CommentPlugin.tsx
+++ b/src/plugins/CommentPlugin.tsx
@@ -109,6 +109,7 @@ function AddCommentBox({
       <button
         className="CommentPlugin_AddCommentBox_button"
         onClick={onAddComment}
+        type="button"
       >
         <i className="icon add-comment" />
       </button>

--- a/src/plugins/TableActionMenuPlugin.tsx
+++ b/src/plugins/TableActionMenuPlugin.tsx
@@ -332,14 +332,14 @@ function TableActionMenu({
         e.stopPropagation();
       }}
     >
-      <button className="item" onClick={() => insertTableRowAtSelection(false)}>
+      <button className="item" onClick={() => insertTableRowAtSelection(false)} type="button">
         <span className="text">
           Insert{' '}
           {selectionCounts.rows === 1 ? 'row' : `${selectionCounts.rows} rows`}{' '}
           above
         </span>
       </button>
-      <button className="item" onClick={() => insertTableRowAtSelection(true)}>
+      <button className="item" onClick={() => insertTableRowAtSelection(true)} type="button">
         <span className="text">
           Insert{' '}
           {selectionCounts.rows === 1 ? 'row' : `${selectionCounts.rows} rows`}{' '}
@@ -350,6 +350,7 @@ function TableActionMenu({
       <button
         className="item"
         onClick={() => insertTableColumnAtSelection(false)}
+        type="button"
       >
         <span className="text">
           Insert{' '}
@@ -362,6 +363,7 @@ function TableActionMenu({
       <button
         className="item"
         onClick={() => insertTableColumnAtSelection(true)}
+        type="button"
       >
         <span className="text">
           Insert{' '}
@@ -372,17 +374,17 @@ function TableActionMenu({
         </span>
       </button>
       <hr />
-      <button className="item" onClick={() => deleteTableColumnAtSelection()}>
+      <button className="item" onClick={() => deleteTableColumnAtSelection()} type="button">
         <span className="text">Delete column</span>
       </button>
-      <button className="item" onClick={() => deleteTableRowAtSelection()}>
+      <button className="item" onClick={() => deleteTableRowAtSelection()} type="button">
         <span className="text">Delete row</span>
       </button>
-      <button className="item" onClick={() => deleteTableAtSelection()}>
+      <button className="item" onClick={() => deleteTableAtSelection()} type="button">
         <span className="text">Delete table</span>
       </button>
       <hr />
-      <button className="item" onClick={() => toggleTableRowIsHeader()}>
+      <button className="item" onClick={() => toggleTableRowIsHeader()} type="button">
         <span className="text">
           {(tableCellNode.__headerState & TableCellHeaderStates.ROW) ===
           TableCellHeaderStates.ROW
@@ -391,7 +393,7 @@ function TableActionMenu({
           row header
         </span>
       </button>
-      <button className="item" onClick={() => toggleTableColumnIsHeader()}>
+      <button className="item" onClick={() => toggleTableColumnIsHeader()} type="button">
         <span className="text">
           {(tableCellNode.__headerState & TableCellHeaderStates.COLUMN) ===
           TableCellHeaderStates.COLUMN
@@ -517,6 +519,7 @@ function TableCellActionMenuContainer(): JSX.Element {
               setIsMenuOpen(!isMenuOpen);
             }}
             ref={menuRootRef}
+            type="button"
           >
             <i className="chevron-down" />
           </button>

--- a/src/plugins/TestRecorderPlugin.tsx
+++ b/src/plugins/TestRecorderPlugin.tsx
@@ -403,6 +403,7 @@ ${steps.map(formatStep).join(`\n`)}
       className={`editor-dev-button ${isRecording ? 'active' : ''}`}
       onClick={() => toggleEditorSelection(getCurrentEditor())}
       title={isRecording ? 'Disable test recorder' : 'Enable test recorder'}
+      type="button"
     />
   );
   const output = isRecording ? (
@@ -413,18 +414,21 @@ ${steps.map(formatStep).join(`\n`)}
           id="test-recorder-button-snapshot"
           title="Insert snapshot"
           onClick={onSnapshotClick}
+          type="button"
         />
         <button
           className="test-recorder-button"
           id="test-recorder-button-copy"
           title="Copy to clipboard"
           onClick={onCopyClick}
+          type="button"
         />
         <button
           className="test-recorder-button"
           id="test-recorder-button-download"
           title="Download as a file"
           onClick={onDownloadClick}
+          type="button"
         />
       </div>
       <pre id="test-recorder" ref={preRef}>

--- a/src/plugins/ToolbarPlugin/components/AlignDropdown.tsx
+++ b/src/plugins/ToolbarPlugin/components/AlignDropdown.tsx
@@ -29,6 +29,7 @@ const AlignDropdown = () => {
           activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'left');
         }}
         className="item"
+        type="button"
       >
         <i className="icon left-align" />
         <span className="text">Left Align</span>
@@ -38,6 +39,7 @@ const AlignDropdown = () => {
           activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'center');
         }}
         className="item"
+        type="button"
       >
         <i className="icon center-align" />
         <span className="text">Center Align</span>
@@ -47,6 +49,7 @@ const AlignDropdown = () => {
           activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'right');
         }}
         className="item"
+        type="button"
       >
         <i className="icon right-align" />
         <span className="text">Right Align</span>
@@ -56,6 +59,7 @@ const AlignDropdown = () => {
           activeEditor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'justify');
         }}
         className="item"
+        type="button"
       >
         <i className="icon justify-align" />
         <span className="text">Justify Align</span>
@@ -66,6 +70,7 @@ const AlignDropdown = () => {
           activeEditor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
         }}
         className="item"
+        type="button"
       >
         <i className={'icon ' + (isRTL ? 'indent' : 'outdent')} />
         <span className="text">Outdent</span>
@@ -75,6 +80,7 @@ const AlignDropdown = () => {
           activeEditor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
         }}
         className="item"
+        type="button"
       >
         <i className={'icon ' + (isRTL ? 'outdent' : 'indent')} />
         <span className="text">Indent</span>

--- a/src/plugins/ToolbarPlugin/components/BlockFormatDropdown.tsx
+++ b/src/plugins/ToolbarPlugin/components/BlockFormatDropdown.tsx
@@ -124,47 +124,47 @@ const BlockFormatDropdown = () => {
       buttonLabel={blockTypeToBlockName[blockType]}
       buttonAriaLabel="Formatting options for text style"
     >
-      <button className="item" onClick={formatParagraph}>
+      <button className="item" onClick={formatParagraph} type="button">
         <span className="icon paragraph" />
         <span className="text">Normal</span>
         {blockType === 'paragraph' && <span className="active" />}
       </button>
-      <button className="item" onClick={() => formatHeading('h1')}>
+      <button className="item" onClick={() => formatHeading('h1')} type="button">
         <span className="icon h1" />
         <span className="text">Heading 1</span>
         {blockType === 'h1' && <span className="active" />}
       </button>
-      <button className="item" onClick={() => formatHeading('h2')}>
+      <button className="item" onClick={() => formatHeading('h2')} type="button">
         <span className="icon h2" />
         <span className="text">Heading 2</span>
         {blockType === 'h2' && <span className="active" />}
       </button>
-      <button className="item" onClick={() => formatHeading('h3')}>
+      <button className="item" onClick={() => formatHeading('h3')} type="button">
         <span className="icon h3" />
         <span className="text">Heading 3</span>
         {blockType === 'h3' && <span className="active" />}
       </button>
-      <button className="item" onClick={formatBulletList}>
+      <button className="item" onClick={formatBulletList} type="button">
         <span className="icon bullet-list" />
         <span className="text">Bullet List</span>
         {blockType === 'bullet' && <span className="active" />}
       </button>
-      <button className="item" onClick={formatNumberedList}>
+      <button className="item" onClick={formatNumberedList} type="button">
         <span className="icon numbered-list" />
         <span className="text">Numbered List</span>
         {blockType === 'number' && <span className="active" />}
       </button>
-      <button className="item" onClick={formatCheckList}>
+      <button className="item" onClick={formatCheckList} type="button">
         <span className="icon check-list" />
         <span className="text">Check List</span>
         {blockType === 'check' && <span className="active" />}
       </button>
-      <button className="item" onClick={formatQuote}>
+      <button className="item" onClick={formatQuote} type="button">
         <span className="icon quote" />
         <span className="text">Quote</span>
         {blockType === 'quote' && <span className="active" />}
       </button>
-      <button className="item" onClick={formatCode}>
+      <button className="item" onClick={formatCode} type="button">
         <span className="icon code" />
         <span className="text">Code Block</span>
         {blockType === 'code' && <span className="active" />}

--- a/src/plugins/ToolbarPlugin/components/BoldButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/BoldButton.tsx
@@ -19,6 +19,7 @@ const BoldButton = () => {
       aria-label={`Format text as bold. Shortcut: ${
         IS_APPLE ? '⌘B' : 'Ctrl+B'
       }`}
+      type="button"
     >
       <i className="format bold" />
     </button>

--- a/src/plugins/ToolbarPlugin/components/CodeFormatButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/CodeFormatButton.tsx
@@ -16,6 +16,7 @@ const CodeFormatButton = () => {
       className={'toolbar-item spaced ' + (isCode ? 'active' : '')}
       title="Insert code block"
       aria-label="Insert code block"
+      type="button"
     >
       <i className="format code" />
     </button>

--- a/src/plugins/ToolbarPlugin/components/InsertDropdown.tsx
+++ b/src/plugins/ToolbarPlugin/components/InsertDropdown.tsx
@@ -388,6 +388,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               );
             }}
             className="item"
+            type="button"
           >
             <i className="icon horizontal-rule" />
             <span className="text">Horizontal Rule</span>
@@ -404,6 +405,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               ));
             }}
             className="item"
+            type="button"
           >
             <i className="icon image" />
             <span className="text">Image</span>
@@ -418,6 +420,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               );
             }}
             className="item"
+            type="button"
           >
             <i className="icon diagram-2" />
             <span className="text">Excalidraw</span>
@@ -435,6 +438,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
                 ));
               }}
               className="item"
+              type="button"
             >
               <i className="icon table" />
               <span className="text">Table</span>
@@ -452,6 +456,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               ));
             }}
             className="item"
+            type="button"
           >
             <i className="icon poll" />
             <span className="text">Poll</span>
@@ -468,6 +473,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               ));
             }}
             className="item"
+            type="button"
           >
             <i className="icon tweet" />
             <span className="text">Tweet</span>
@@ -484,6 +490,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               ));
             }}
             className="item"
+            type="button"
           >
             <i className="icon youtube" />
             <span className="text">YouTube Video</span>
@@ -500,6 +507,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               ));
             }}
             className="item"
+            type="button"
           >
             <i className="icon equation" />
             <span className="text">Equation</span>
@@ -515,6 +523,7 @@ const InsertDropdown: React.FC<IInsertDropdownProps> = ({
               });
             }}
             className="item"
+            type="button"
           >
             <i className="icon sticky" />
             <span className="text">Sticky Note</span>

--- a/src/plugins/ToolbarPlugin/components/InsertLinkButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/InsertLinkButton.tsx
@@ -16,6 +16,7 @@ const InsertLinkButton = () => {
         className={'toolbar-item spaced ' + (isLink ? 'active' : '')}
         aria-label="Insert link"
         title="Insert link"
+        type="button"
       >
         <i className="format link" />
       </button>

--- a/src/plugins/ToolbarPlugin/components/ItalicButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/ItalicButton.tsx
@@ -19,6 +19,7 @@ const ItalicButton = () => {
       aria-label={`Format text as italics. Shortcut: ${
         IS_APPLE ? '⌘I' : 'Ctrl+I'
       }`}
+      type="button"
     >
       <i className="format italic" />
     </button>

--- a/src/plugins/ToolbarPlugin/components/RedoButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/RedoButton.tsx
@@ -17,6 +17,7 @@ const RedoButton = () => {
       title={IS_APPLE ? 'Redo (⌘Y)' : 'Undo (Ctrl+Y)'}
       className="toolbar-item"
       aria-label="Redo"
+      type="button"
     >
       <i className="format redo" />
     </button>

--- a/src/plugins/ToolbarPlugin/components/TextFormatDropdown.tsx
+++ b/src/plugins/ToolbarPlugin/components/TextFormatDropdown.tsx
@@ -24,6 +24,7 @@ const TextFormatDropdown = () => {
         }
         title="Strikethrough"
         aria-label="Format text with a strikethrough"
+        type="button"
       >
         <i className="icon strikethrough" />
         <span className="text">Strikethrough</span>
@@ -35,6 +36,7 @@ const TextFormatDropdown = () => {
         className={'item ' + (isSubscript ? 'active dropdown-item-active' : '')}
         title="Subscript"
         aria-label="Format text with a subscript"
+        type="button"
       >
         <i className="icon subscript" />
         <span className="text">Subscript</span>
@@ -48,6 +50,7 @@ const TextFormatDropdown = () => {
         }
         title="Superscript"
         aria-label="Format text with a superscript"
+        type="button"
       >
         <i className="icon superscript" />
         <span className="text">Superscript</span>

--- a/src/plugins/ToolbarPlugin/components/UnderlineButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/UnderlineButton.tsx
@@ -19,6 +19,7 @@ const UnderlineButton = () => {
       aria-label={`Format text to underlined. Shortcut: ${
         IS_APPLE ? '⌘U' : 'Ctrl+U'
       }`}
+      type="button"
     >
       <i className="format underline" />
     </button>

--- a/src/plugins/ToolbarPlugin/components/UndoButton.tsx
+++ b/src/plugins/ToolbarPlugin/components/UndoButton.tsx
@@ -17,6 +17,7 @@ const UndoButton = () => {
       title={IS_APPLE ? 'Undo (⌘Z)' : 'Undo (Ctrl+Z)'}
       className="toolbar-item spaced"
       aria-label="Undo"
+      type="button"
     >
       <i className="format undo" />
     </button>

--- a/src/ui/ColorPicker.tsx
+++ b/src/ui/ColorPicker.tsx
@@ -104,6 +104,7 @@ export default function ColorPicker({
               key={basicColor}
               style={{ backgroundColor: basicColor }}
               onClick={() => setSelfColor(transformColor('hex', basicColor))}
+              type="button"
             />
           ))}
         </div>

--- a/src/ui/DropDown.tsx
+++ b/src/ui/DropDown.tsx
@@ -71,6 +71,7 @@ export default function DropDown({
         className={buttonClassName}
         onClick={() => setShowDropDown(!showDropDown)}
         ref={buttonRef}
+        type="button"
       >
         {buttonIconClassName && <span className={buttonIconClassName} />}
         {buttonLabel && (


### PR DESCRIPTION
Hi,

This pull request is converting all buttons from submit to button. It is required to avoid submit when use the editor inside a form.

```jsx
<form>
    <Editor />
</form>

```

Thanks.