### PR TITLE
Fix for Equation Node Serialization

### DIFF
--- a/src/nodes/EquationNode.tsx
+++ b/src/nodes/EquationNode.tsx
@@ -154,7 +154,7 @@ export class EquationNode extends DecoratorNode<JSX.Element> {
     return {
       equation: this.getEquation(),
       inline: this.__inline,
-      type: 'emoji',
+      type: 'equation',
       version: 1,
     };
   }


### PR DESCRIPTION
Hi there!

This pull is a very small fix to enable equation nodes (math/latex) to be serialized. Currently the `exportJSON()` method fails client-side due to the `type` property of the serialized return object being emoji instead of equation.

<img width="497" alt="Screen Shot 2022-08-15 at 11 46 51 PM" src="https://user-images.githubusercontent.com/10041771/184799850-e36ccdf8-68ee-4ecc-94e4-b803b812477b.png">

To test:
1. In the storybook component, add `enableEquations` to `<InsertDropdown/>` component and add a console log to the `onChange` event. For convenience: 
```javascript
export const FullEditor = () => (
  <EditorComposer>
    <Editor onChange={stringifiedNodes => console.log(stringifiedNodes)}>
      <ToolbarPlugin>
        <FontFamilyDropdown />
        <FontSizeDropdown />
        <Divider />
        <BoldButton />
        <ItalicButton />
        <UnderlineButton />
        <CodeFormatButton />
        <InsertLinkButton />
        <TextColorPicker />
        <BackgroundColorPicker />
        <TextFormatDropdown />
        <Divider />
        <InsertDropdown enableEquations />
        <Divider />
        <AlignDropdown />
      </ToolbarPlugin>
    </Editor>
  </EditorComposer>
);
```
2. Add any equation to the Storybook playground
3. Profit!