### PR TITLE
Fixing app crashing when locale not null

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -37,7 +37,7 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import EditorContext from './context/EditorContext';
 import { LexicalEditor } from 'lexical';
-import i18next from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 interface IEditorProps {
   children?: ReactNode;
@@ -74,10 +74,12 @@ const Editor = ({
   } = useSettings();
   const placeholderComponent = <Placeholder>{placeholder}</Placeholder>;
 
+  const { i18n } = useTranslation();
+
   useEffect(() => {
     editor.setEditable(isEditable);
 
-    if (locale) i18next.changeLanguage(locale);
+    if (locale) i18n.changeLanguage(locale);
   }, []);
 
   return (

--- a/src/EditorComposer.tsx
+++ b/src/EditorComposer.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 import PlaygroundNodes from './nodes/PlaygroundNodes';
 import PlaygroundEditorTheme from './themes/PlaygroundEditorTheme';
 import './EditorComposer.css';
-import './locale';
+import i18n from './locale';
+import { I18nextProvider } from 'react-i18next';
 
 interface IEditorComposer {
   children: React.ReactElement;
@@ -25,7 +26,9 @@ const EditorComposer = ({ children, initialEditorState }: IEditorComposer) => {
   };
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <div className="editor-shell">{children}</div>
+      <I18nextProvider i18n={i18n}>
+        <div className="editor-shell">{children}</div>
+      </I18nextProvider>
     </LexicalComposer>
   );
 };

--- a/src/locale/index.tsx
+++ b/src/locale/index.tsx
@@ -1,9 +1,8 @@
 import * as i18next from 'i18next';
-import { initReactI18next } from 'react-i18next';
 import EN from './languages/en.json';
 import FR from './languages/fr.json';
 import PTBR from './languages/ptBr.json';
-import RU from './languages/ru.json'
+import RU from './languages/ru.json';
 
 export const resources = {
   ar: {},
@@ -33,17 +32,20 @@ export const languageDetector = {
   cacheUserLanguage: () => {},
 };
 
-export const i18n = i18next
-  .use(initReactI18next)
-  .use(languageDetector as i18next.Module)
-  .init({
-    ns: ['toolbar', 'action'],
-    resources,
-    fallbackLng: 'en',
-    debug: true,
-    interpolation: {
-      escapeValue: false,
+const i18n = i18next
+  .createInstance(
+    {
+      ns: ['toolbar', 'action'],
+      resources,
+      fallbackLng: 'en',
+      debug: true,
+      interpolation: {
+        escapeValue: false,
+      },
     },
-  });
+    // We must provide a function as second parameter, otherwise i18next errors
+    (err, t) => {}
+  )
+  .use(languageDetector as i18next.Module);
 
 export default i18n;


### PR DESCRIPTION
The problem was `export const i18n = i18next.use...` is not creating a new instance (`i18n` had type `any`, means `i18n.changeLanguage()` can't be call). We should use `i18next.createInstance`.

Also i tested it with my project, and there is was a problem with other global instance of `i18next` (used in my app). One of the instances was dominant, so the second didn't work correctly. To avoid it we should use `I18nextProvider ` to separate from each other. 

Solution for #24 and #25.

Please review and test it before merge.
Hope it help.