### PR TITLE
Publish package to npmjs using GitHub Actions

### DIFF
--- a/.github/workflows/npmjs.yml
+++ b/.github/workflows/npmjs.yml
@@ -1,0 +1,17 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
Hey @ozanyurtsever, here is a GH actions workflow that help you to automatically [publish](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) a new version of Verbum to NPM, it trigger by publish a new release. 

For use it, you need to create authentication [token](https://docs.npmjs.com/creating-and-viewing-access-tokens) and [add](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) it for your project.

My test [repo](https://github.com/DiggesT/verbum-deploy-test/tree/actions/deploy) and [package](https://www.npmjs.com/package/verbum-deploy-test).