### PR TITLE
Revert "CSS namespaces"

### DIFF
--- a/src/EditorComposer.css
+++ b/src/EditorComposer.css
@@ -8,8 +8,6 @@
 
 @import 'https://fonts.googleapis.com/css?family=Reenie+Beanie';
 
-@namespace "Verbum-EditorComposer";
-
 .editor-shell {
   margin: 20px auto;
   border-radius: 2px;

--- a/src/EditorComposer.tsx
+++ b/src/EditorComposer.tsx
@@ -27,9 +27,7 @@ const EditorComposer = ({ children, initialEditorState }: IEditorComposer) => {
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <I18nextProvider i18n={i18n}>
-        <svg xmlns="Verbum-EditorComposer">
-          <div className="editor-shell">{children}</div>
-        </svg>
+        <div className="editor-shell">{children}</div>
       </I18nextProvider>
     </LexicalComposer>
   );

--- a/src/plugins/ToolbarPlugin/ToolbarPlugin.css
+++ b/src/plugins/ToolbarPlugin/ToolbarPlugin.css
@@ -6,8 +6,6 @@
  *
  *
  */
-@namespace 'Verbum-toolbar';
-
 .ToolbarPlugin__dialogActions {
   display: flex;
   flex-direction: row;

--- a/src/plugins/ToolbarPlugin/ToolbarPlugin.tsx
+++ b/src/plugins/ToolbarPlugin/ToolbarPlugin.tsx
@@ -265,29 +265,26 @@ const ToolbarPlugin = ({
         blockType,
       }}
     >
-      <svg xmlns="Verbum-toolbar">
-        <div className="toolbar">
-          <UndoButton />
-          <RedoButton />
-          <Divider />
-          {supportedBlockTypes.has(blockType) &&
-            activeEditor === initialEditor && (
-              <>
-                <BlockFormatDropdown />
-                <Divider />
-              </>
-            )}
-          {blockType === 'code' ? (
-            <>
-              <CodeLanguageDropdown />
-              <Divider />
-              {alignExists && AlignComponent}
-            </>
-          ) : (
-            <>{children}</>
-          )}
-        </div>
-      </svg>
+      <div className="toolbar">
+        <UndoButton />
+        <RedoButton />
+        <Divider />
+        {supportedBlockTypes.has(blockType) && activeEditor === initialEditor && (
+          <>
+            <BlockFormatDropdown />
+            <Divider />
+          </>
+        )}
+        {blockType === 'code' ? (
+          <>
+            <CodeLanguageDropdown />
+            <Divider />
+            {alignExists && AlignComponent}
+          </>
+        ) : (
+          <>{children}</>
+        )}
+      </div>
     </ToolbarContext.Provider>
   );
 };


### PR DESCRIPTION
@DiggesT Hello,

I had to revert this commit because the storybook was not getting built properly. Maybe you can take a look at it again? 

I received the following error while running storybook when this commit was included;

```
Cannot read properties of undefined (reading 'length')
TypeError: Cannot read properties of undefined (reading 'length')
    at updateOptions (http://localhost:6006/vendors~main.iframe.bundle.js:129682:37)
    at postMountWrapper$2 (http://localhost:6006/vendors~main.iframe.bundle.js:129750:5)
    at setInitialProperties (http://localhost:6006/vendors~main.iframe.bundle.js:137488:7)
    at finalizeInitialChildren (http://localhost:6006/vendors~main.iframe.bundle.js:138495:3)
    at completeWork (http://localhost:6006/vendors~main.iframe.bundle.js:149733:17)
    at completeUnitOfWork (http://localhost:6006/vendors~main.iframe.bundle.js:154136:16)
    at performUnitOfWork (http://localhost:6006/vendors~main.iframe.bundle.js:154108:5)
    at workLoopSync (http://localhost:6006/vendors~main.iframe.bundle.js:154006:5)
    at renderRootSync (http://localhost:6006/vendors~main.iframe.bundle.js:153974:7)
    at recoverFromConcurrentError (http://localhost:6006/vendors~main.iframe.bundle.js:153390:20)
```