### PR TITLE
fix: useEffect to set editor.tsx#isEditable

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -84,7 +84,7 @@ const Editor = ({
     editor.setEditable(isEditable);
 
     if (locale) i18n.changeLanguage(locale);
-  }, []);
+  }, [isEditable]);
 
   return (
     <EditorContext.Provider

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -70,7 +70,7 @@ const Editor = ({
 }: IEditorProps) => {
   const [editor] = useLexicalComposerContext();
   const [activeEditor, setActiveEditor] = useState(editor);
-
+  const [_isEditable, setIsEditable] = useState(isEditable);
   const editorStateRef = useRef(null);
   const { historyState } = useSharedHistoryContext();
   const {
@@ -82,6 +82,8 @@ const Editor = ({
 
   useEffect(() => {
     editor.setEditable(isEditable);
+
+    setIsEditable(isEditable);
 
     if (locale) i18n.changeLanguage(locale);
   }, [isEditable]);
@@ -121,7 +123,7 @@ const Editor = ({
           <ListMaxIndentLevelPlugin maxDepth={listMaxIndent} />
           <LinkPlugin />
           <ClickableLinkPlugin />
-          <CharacterStylesPopupPlugin />
+          {_isEditable && <CharacterStylesPopupPlugin />}
           <TabFocusPlugin />
         </>
 


### PR DESCRIPTION
**Current behavior:** Externally changing the value of isEditable doesn't trigger a re-render and editor remains in same state.

**New behavior ** Externally changing the value of isEditable triggers a re-render and editor responds appropriately.

**Context** For example, it may be desireable for consuming code to lock the editor until a "Checkout for editing" button is clicked upon which server-side state reflects the fact that a specific user is currently editing the content as a primitive way of preventing merge conflicts.