### PR TITLE
fix: fix dropdown y alignment when window is scrolled down

### DIFF
--- a/src/ui/DropDown.tsx
+++ b/src/ui/DropDown.tsx
@@ -35,7 +35,7 @@ export default function DropDown({
 
     if (showDropDown && button !== null && dropDown !== null) {
       const { top, left } = button.getBoundingClientRect();
-      dropDown.style.top = `${top + 40}px`;
+      dropDown.style.top = `${top + 40 + window.scrollY}px`;
       dropDown.style.left = `${Math.min(
         left,
         window.innerWidth - dropDown.offsetWidth - 20


### PR DESCRIPTION
Simple fix of #74 where the dropdown menu origin would not follow the position of the editor if the page is scrolled down.

Before
<img width="996" alt="Screenshot 2024-07-27 at 14 34 56" src="https://github.com/user-attachments/assets/e4823d1f-4a91-4bd1-b492-edc88a3b6dcd">

After fix
<img width="1011" alt="Screenshot 2024-07-27 at 14 35 15" src="https://github.com/user-attachments/assets/73664f8a-0724-4595-b8d0-72075adea5ba">
